### PR TITLE
Feature/admin get tweets/users

### DIFF
--- a/src/apis/admin.js
+++ b/src/apis/admin.js
@@ -1,0 +1,24 @@
+import { apiHelper } from "../utils/helpers";
+const getToken = () => localStorage.getItem('token')
+
+export default {
+  tweets: {
+    get() {
+      return apiHelper.get('/tweets', {
+        headers: { Authorization : `Bearer ${getToken()}`  }
+      })
+    },
+    delete({tweetId}) {
+      return apiHelper.delete(`/admin/tweets/${tweetId}`, {
+        headers: { Authorization: `Bearer ${getToken()}` }
+      })
+    }
+  },
+  users: {
+    get() {
+      return apiHelper.get('/admin/users', {
+        headers: { Authorization: `Bearer ${getToken()}` }
+      })
+    }
+  }
+}

--- a/src/apis/users.js
+++ b/src/apis/users.js
@@ -3,7 +3,7 @@ const getToken = () => localStorage.getItem('token')
 
 export default {
   getCurrentUser() {
-    return apiHelper.get('/currentUser', {
+    return apiHelper.get('/users/currentUser', {
       headers: { Authorization : `Bearer ${getToken()}`}
     })
   }

--- a/src/components/AdminTweetsList.vue
+++ b/src/components/AdminTweetsList.vue
@@ -22,6 +22,9 @@
 <script>
 import { fromNowFilter } from "./../utils/mixins";
 import { emptyImageFilter } from "./../utils/mixins";
+import { Toast } from './../utils/helpers'
+import adminAPI from './../apis/admin'
+
 export default {
   name: 'AdminTweetsList',
   mixins: [fromNowFilter, emptyImageFilter],
@@ -32,11 +35,26 @@ export default {
     }
   },
   methods: {
-    handleDeleteBtnClick(tweetId) {
-      //TODO:發送API請伺服器刪掉這則tweet
-      // 告訴父元件哪一條tweet被刪掉
-      console.log('delete', tweetId)
-      this.$emit('after-delete-tweet', tweetId)
+    async handleDeleteBtnClick(tweetId) {
+      try { 
+        // 發送API請伺服器刪掉這則tweet
+        const { data } = await adminAPI.tweets.delete({tweetId})
+        if (data.status === 'error') {
+          throw new Error(data.message)
+        }
+        // 告訴父元件哪一條tweet被刪掉
+        this.$emit('after-delete-tweet', tweetId)
+        Toast.fire({
+          icon: 'success',
+          title: '推文刪除成功'
+        })
+      } catch (error) {
+        console.error(error)
+        Toast.fire({
+          icon: 'error',
+          title: '無法刪除此推文，請稍後再試'
+        }) 
+      }
     }
   },
   filters: {

--- a/src/components/AdminTweetsList.vue
+++ b/src/components/AdminTweetsList.vue
@@ -49,7 +49,7 @@ export default {
           title: '推文刪除成功'
         })
       } catch (error) {
-        console.error(error)
+        console.error(error.message)
         Toast.fire({
           icon: 'error',
           title: '無法刪除此推文，請稍後再試'
@@ -59,11 +59,7 @@ export default {
   },
   filters: {
     onlyDisplay50Letters(string) {
-      if (string.length > 50) {
-        return string.slice(0, 50) + "..."
-      } else { 
-        return string 
-      }
+      return string.length > 50 ? string.slice(0, 50) + "..." : string 
     }
   }
 }

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -5,7 +5,7 @@
         <div class="nav-top">
           <img class="logo-img" src="~@/assets/image/logo.png" alt="logo-img" />
           <!-- 在該頁面時, icon和選項文字變成橘色 -->
-          <div class="home-btn nav-item btn-clicked" v-if="this.$route.name === 'main-page'">
+          <div class="home-btn nav-item btn-clicked" v-if="$route.name === 'main-page' || $route.name === 'reply-list'">
             <img class="home-icon" src="~@/assets/image/home-orange.png" alt="home-icon">
             <p class="nav-text">首頁</p>
           </div>
@@ -19,7 +19,7 @@
             <router-link to="/main" class="nav-text">首頁</router-link>
           </div>
           <div class="user-profile-btn nav-item btn-clicked" 
-            v-if="this.$route.name === 'main-tweets' || this.$route.name === 'replies' || this.$route.name === 'liked-tweets'">
+            v-if="$route.name === 'main-tweets' || $route.name === 'replies' || $route.name === 'liked-tweets'">
             <img class="user-icon" src="~@/assets/image/user-orange.png" alt="user-icon">
             <p class="nav-text">個人資料</p>
           </div>
@@ -31,7 +31,7 @@
             />
             <router-link :to="{name: 'user', params: {id: currentUser.id } }" class="nav-text">個人資料</router-link>
           </div>
-          <div class="setting-btn nav-item btn-clicked" v-if="this.$route.name === 'setting'">
+          <div class="setting-btn nav-item btn-clicked" v-if="$route.name === 'setting'">
             <img  class="setting-icon" src="~@/assets/image/setting-orange.png" alt="setting-icon">
             <p class="nav-text">設定</p>
           </div>
@@ -51,7 +51,7 @@
       <template v-else>
         <div class="nav-top">
           <img class="logo-img" src="~@/assets/image/logo.png" alt="logo-img">
-          <div class="home-btn nav-item btn-clicked" v-if="this.$route.name === 'admin-tweets'">
+          <div class="home-btn nav-item btn-clicked" v-if="$route.name === 'admin-tweets'">
             <img class="home-icon" src="~@/assets/image/home-orange.png" alt="home-icon">
             <p class="nav-text">推文清單</p>
           </div>
@@ -59,7 +59,7 @@
             <img class="home-icon" src="~@/assets/image/home.png" alt="home-icon">
             <router-link :to="{name: 'admin-tweets'}" class="nav-text">推文清單</router-link>
           </div>
-          <div class="user-profile-btn nav-item btn-clicked" v-if="this.$route.name === 'admin-users'">
+          <div class="user-profile-btn nav-item btn-clicked" v-if="$route.name === 'admin-users'">
             <img class="user-icon" src="~@/assets/image/user-orange.png" alt="user-icon">
             <p class="nav-text">使用者列表</p>
           </div>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -14,7 +14,7 @@ export default new Vuex.Store({
       avatar: '',
       role: ''
     },
-    isAuthenticated: false
+    isAuthenticated: false,
   },
   getters: {
   },
@@ -26,6 +26,7 @@ export default new Vuex.Store({
       }
       // 改變登入狀態
       state.isAuthenticated = true
+      state.token = localStorage.getItem('token')
     },
     // 登出
     revokeAuthentication(state) {
@@ -45,10 +46,11 @@ export default new Vuex.Store({
         commit('setCurrentUser', {
           id, name, account, email, avatar, role
         })
-        return true //登入有效
+        return {isAuthenticated : true, role: this.state.currentUser.role} //登入有效
       } catch (error) {
         console.error(error.message)
-        return false  //登入無效
+        commit('revokeAuthentication') // 登入無效直接把使用者登出
+        return { isAuthenticated: false, role: '' }  //登入無效
       }
     }
   },

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,10 +1,12 @@
 import axios from 'axios'
 
-// TODO: 更改Api baseURL
-const baseURL = 'https://rocky-sea-34138.herokuapp.com/api'
+const baseURL = 'https://twitter-api-2022.herokuapp.com/api'
 
 export const apiHelper = axios.create({
-  baseURL
+  baseURL,
+  validateStatus: function (status) {
+    return status >= 200 && status < 500; 
+  },
 })
 import Swal from 'sweetalert2'
 

--- a/src/views/AdminLogin.vue
+++ b/src/views/AdminLogin.vue
@@ -88,7 +88,7 @@ export default {
           throw new Error(data.message);
         }
         // 如果登入成功, 存下token, 並直接轉址首頁
-        localStorage.setItem("adminToken", data.token);
+        localStorage.setItem("token", data.token);
         // 把API回傳的登入使用者資料存到Vuex
         this.$store.commit("setCurrentUser", data.user);
         // 登入成功, 直接轉址後台頁面

--- a/src/views/AdminTweets.vue
+++ b/src/views/AdminTweets.vue
@@ -8,125 +8,9 @@
 <script>
 import Navbar from './../components/Navbar.vue'
 import AdminTweetsList from './../components/AdminTweetsList.vue'
+import adminAPI from './../apis/admin'
+import { Toast } from './../utils/helpers'
 
-const dummyData = { 
-  tweets: [
-    {
-        "id": 18,
-        "UserId": 3,
-        "description": "balabala",
-        "createdAt": "2022-07-29T13:04:27.000Z",
-        "updatedAt": "2022-07-29T14:25:43.000Z",
-        "userId": 3,
-        "User": {
-            "id": 3,
-            "name": "user2",
-            "account": "user2",
-            "avatar": "https://joeschmoe.io/api/v1/random"
-        }
-    },
-    {
-        "id": 8,
-        "UserId": 2,
-        "description": "balabababa",
-        "createdAt": "2022-07-29T09:08:43.000Z",
-        "updatedAt": "2022-07-29T14:25:43.000Z",
-        "userId": 2,
-        "User": {
-            "id": 2,
-            "name": "user1",
-            "account": "user1",
-            "avatar": "https://joeschmoe.io/api/v1/random"
-        },   
-    },
-    {
-        "id": 5,
-        "UserId": 3,
-        "description": "Nulla Lorem mollit cupidatat irure. Laborum magna nulla duis ullamco cillum dolor. Voluptate exercitation incididunt aliquip deserunt reprehenderit elit laborum.",
-        "createdAt": "2022-07-29T09:08:43.000Z",
-        "updatedAt": "2022-07-29T14:25:43.000Z",
-        "userId": 3,
-        "User": {
-            "id": 3,
-            "name": "apple",
-            "account": "apple",
-            "avatar": "https://joeschmoe.io/api/v1/random"
-        },   
-    },
-    {
-        "id": 9,
-        "UserId": 3,
-        "description": "Nulla Lorem mollit cupidatat irure. Laborum magna nulla duis ullamco cillum dolor. Voluptate exercitation incididunt aliquip deserunt reprehenderit elit laborum.",
-        "createdAt": "2022-07-29T09:08:43.000Z",
-        "updatedAt": "2022-07-29T14:25:43.000Z",
-        "userId": 3,
-        "User": {
-            "id": 3,
-            "name": "apple",
-            "account": "apple",
-            "avatar": "https://joeschmoe.io/api/v1/random"
-        },   
-    },
-    {
-        "id": 7,
-        "UserId": 3,
-        "description": "Nulla Lorem mollit cupidatat irure. Laborum magna nulla duis ullamco cillum dolor. Voluptate exercitation incididunt aliquip deserunt reprehenderit elit laborum.",
-        "createdAt": "2022-07-29T09:08:43.000Z",
-        "updatedAt": "2022-07-29T14:25:43.000Z",
-        "userId": 3,
-        "User": {
-            "id": 3,
-            "name": "apple",
-            "account": "apple",
-            "avatar": "https://joeschmoe.io/api/v1/random"
-        },   
-    },
-    {
-        "id": 66,
-        "UserId": 3,
-        "description": "Nulla Lorem mollit cupidatat irure. Laborum magna nulla duis ullamco cillum dolor. Voluptate exercitation incididunt aliquip deserunt reprehenderit elit laborum.",
-        "createdAt": "2022-07-29T09:08:43.000Z",
-        "updatedAt": "2022-07-29T14:25:43.000Z",
-        "userId": 3,
-        "User": {
-            "id": 3,
-            "name": "apple",
-            "account": "apple",
-            "avatar": "https://joeschmoe.io/api/v1/random"
-        },   
-    },
-    {
-        "id": 75,
-        "UserId": 3,
-        "description": "Nulla Lorem mollit cupidatat irure. Laborum magna nulla duis ullamco cillum dolor. Voluptate exercitation incididunt aliquip deserunt reprehenderit elit laborum.",
-        "createdAt": "2022-07-29T09:08:43.000Z",
-        "updatedAt": "2022-07-29T14:25:43.000Z",
-        "userId": 3,
-        "User": {
-            "id": 3,
-            "name": "apple",
-            "account": "apple",
-            "avatar": "https://joeschmoe.io/api/v1/random"
-        },   
-    },
-    {
-        "id": 45,
-        "UserId": 3,
-        "description": "一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十",
-        "createdAt": "2022-07-29T09:08:43.000Z",
-        "updatedAt": "2022-07-29T14:25:43.000Z",
-        "userId": 3,
-        "User": {
-            "id": 3,
-            "name": "apple",
-            "account": "apple",
-            "avatar": "https://joeschmoe.io/api/v1/random"
-        },   
-    },
-    
-]
-
-}
 export default {
   name: "AdminTweets",
   components: {
@@ -142,8 +26,21 @@ export default {
     this.fetchTweets()
   },
   methods: {
-    fetchTweets() {
-      this.tweets = dummyData.tweets
+    async fetchTweets() {
+      try {
+        const {data} = await adminAPI.tweets.get()
+        if (data.status === 'error') {
+          throw new Error (data.message)
+        }
+        const tweets = data 
+        this.tweets = tweets
+      } catch (error) {
+        console.error(error)
+        Toast.fire({
+          icon: 'error',
+          title: '無法取得推文資料，請稍後再試'
+        })
+      }
     },
     // 刪除tweet
     afterTweetDelete(tweetId) {

--- a/src/views/AdminTweets.vue
+++ b/src/views/AdminTweets.vue
@@ -32,13 +32,12 @@ export default {
         if (data.status === 'error') {
           throw new Error (data.message)
         }
-        const tweets = data 
-        this.tweets = tweets
+        this.tweets = data
       } catch (error) {
-        console.error(error)
+        console.error(error.message)
         Toast.fire({
           icon: 'error',
-          title: '無法取得推文資料，請稍後再試'
+          title: '無法取得推文清單資料，請稍後再試'
         })
       }
     },

--- a/src/views/AdminUsers.vue
+++ b/src/views/AdminUsers.vue
@@ -9,154 +9,8 @@
 <script>
 import Navbar from "./../components/Navbar.vue";
 import AdminUserCards from "./../components/AdminUserCards.vue";
-const dummyData = {
-  users: [
-    {
-      id: 14,
-      name: "user1",
-      account: "user1",
-      avatar: "https://joeschmoe.io/api/v1/random",
-      cover:
-        "https://github.com/ritachien/twitter-api-2022/blob/main/assets/default-cover.png?raw=true",
-      tweetCount: 10000,
-      likeCount: 329,
-      followingCount: 3214,
-      followerCount: 1000,
-    },
-    {
-      id: 24,
-      name: "user2",
-      account: "user2",
-      avatar: "https://joeschmoe.io/api/v1/random",
-      cover:
-        "https://github.com/ritachien/twitter-api-2022/blob/main/assets/default-cover.png?raw=true",
-      tweetCount: 1000000,
-      likeCount: 2330000,
-      followingCount: 25600,
-      followerCount: 1563,
-    },
-    {
-      id: 34,
-      name: "user3",
-      account: "user3",
-      avatar: "https://joeschmoe.io/api/v1/random",
-      cover:
-        "https://github.com/ritachien/twitter-api-2022/blob/main/assets/default-cover.png?raw=true",
-      tweetCount: 55689,
-      likeCount: 7613,
-      followingCount: 22000,
-      followerCount: 55555,
-    },
-    {
-      id: 44,
-      name: "user4",
-      account: "user4",
-      avatar: "https://joeschmoe.io/api/v1/random",
-      cover:
-        "https://github.com/ritachien/twitter-api-2022/blob/main/assets/default-cover.png?raw=true",
-      tweetCount: 10,
-      likeCount: 28,
-      followingCount: 2,
-      followerCount: 2,
-    },
-    {
-      id: 54,
-      name: "user5",
-      account: "user5",
-      avatar: "https://joeschmoe.io/api/v1/random",
-      cover:
-        "https://github.com/ritachien/twitter-api-2022/blob/main/assets/default-cover.png?raw=true",
-      tweetCount: 10,
-      likeCount: 28,
-      followingCount: 1,
-      followerCount: 2,
-    },
-    {
-      id: 4,
-      name: "root",
-      account: "root",
-      avatar: "https://joeschmoe.io/api/v1/random",
-      cover:
-        "https://github.com/ritachien/twitter-api-2022/blob/main/assets/default-cover.png?raw=true",
-      tweetCount: 0,
-      likeCount: 0,
-      followingCount: 0,
-      followerCount: 0,
-    },
-        {
-      id: 4,
-      name: "root",
-      account: "root",
-      avatar: "https://joeschmoe.io/api/v1/random",
-      cover:
-        "https://github.com/ritachien/twitter-api-2022/blob/main/assets/default-cover.png?raw=true",
-      tweetCount: 0,
-      likeCount: 0,
-      followingCount: 0,
-      followerCount: 0,
-    },
-        {
-      id: 4,
-      name: "root",
-      account: "root",
-      avatar: "https://joeschmoe.io/api/v1/random",
-      cover:
-        "https://github.com/ritachien/twitter-api-2022/blob/main/assets/default-cover.png?raw=true",
-      tweetCount: 0,
-      likeCount: 0,
-      followingCount: 0,
-      followerCount: 0,
-    },
-        {
-      id: 4,
-      name: "root",
-      account: "root",
-      avatar: "https://joeschmoe.io/api/v1/random",
-      cover:
-        "https://github.com/ritachien/twitter-api-2022/blob/main/assets/default-cover.png?raw=true",
-      tweetCount: 0,
-      likeCount: 0,
-      followingCount: 0,
-      followerCount: 0,
-    },
-        {
-      id: 4,
-      name: "root",
-      account: "root",
-      avatar: "https://joeschmoe.io/api/v1/random",
-      cover:
-        "https://github.com/ritachien/twitter-api-2022/blob/main/assets/default-cover.png?raw=true",
-      tweetCount: 0,
-      likeCount: 0,
-      followingCount: 0,
-      followerCount: 0,
-    },
-        {
-      id: 4,
-      name: "root",
-      account: "root",
-      avatar: "https://joeschmoe.io/api/v1/random",
-      cover:
-        "https://github.com/ritachien/twitter-api-2022/blob/main/assets/default-cover.png?raw=true",
-      tweetCount: 0,
-      likeCount: 0,
-      followingCount: 0,
-      followerCount: 0,
-    },
-        {
-      id: 4,
-      name: "root",
-      account: "root",
-      avatar: "https://joeschmoe.io/api/v1/random",
-      cover:
-        "https://github.com/ritachien/twitter-api-2022/blob/main/assets/default-cover.png?raw=true",
-      tweetCount: 0,
-      likeCount: 0,
-      followingCount: 0,
-      followerCount: 0,
-    },
-  ],
-};
+import adminAPI from './../apis/admin'
+import { Toast } from './../utils/helpers'
 export default {
   name: "AdminUsers",
   components: {
@@ -172,8 +26,21 @@ export default {
     this.fetchUsers()
   },
   methods: {
-    fetchUsers() {
-      this.users = dummyData.users
+    async fetchUsers() {
+      try {
+        const response = await adminAPI.users.get() 
+        const { data } = response
+        if (response.statusText !== 'OK') {
+          throw new Error(data.message)
+        }
+        this.users = data
+      } catch (error) {
+        console.error(error.message)
+        Toast.fire({
+          icon: 'error',
+          title: '無法取得使用者清單資料，請稍後再試'
+        })
+      }
     }
   },
 };

--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -18,7 +18,7 @@
             placeholder="請輸入帳號"
             required
           />
-          <div class="alert-msg">
+          <div class="alert-msg" v-if="errorMsg === 'Account already exists. Please try another one.'">
             <span class="msg">account已重複註冊！</span>
           </div>
         </div>
@@ -50,7 +50,7 @@
             placeholder="請輸入Email"
             required
           />
-          <div class="alert-msg">
+          <div class="alert-msg" v-if="errorMsg === 'Email already exists. Please try another one.'">
             <span class="msg">Email已重複註冊！</span>
           </div>
         </div>
@@ -101,7 +101,8 @@ export default {
       email: "",
       password: "",
       checkPassword: "",
-      isProcessing: false
+      isProcessing: false,
+      errorMsg: ''
     };
   },
   methods: {
@@ -142,7 +143,9 @@ export default {
           password: this.password,
           checkPassword: this.checkPassword,
         })
-        if (data.status !== 'success') {
+        
+        console.log(data)
+        if (data.status === 'error') {
           throw new Error (data.message)
         }
         // 如果註冊成功, 轉址登入頁
@@ -153,10 +156,26 @@ export default {
         this.$router.push("/login");
       } catch (error) {
         this.isProcessing = false
-        Toast.fire({
-          icon: 'error',
-          title: '註冊失敗，請重新嘗試'
-        })
+        console.error(error.message)
+        if (error.message === 'Account already exists. Please try another one.') {
+          this.errorMsg = error.message
+            Toast.fire({
+            icon: "error",
+            title: "account已重複註冊！",
+          });
+        } else if (error.message === 'Email already exists. Please try another one.') {
+          this.errorMsg = error.message
+          Toast.fire({
+            icon: "error",
+            title: "Email已重複註冊！",
+          });
+        } else {
+          this.errorMsg = error.message
+          Toast.fire({
+            icon: 'error',
+            title: '註冊失敗，請重新嘗試'
+          })
+        }
       }
     },
   },


### PR DESCRIPTION
1. 更新後端伺服器網址, 更新currentUser API路由
2. 修正導覽列在前後台顯示錯誤的問題(adminToken改為token)
3. 根據後端伺服器回傳資料, 將表單驗證錯誤項顯示在註冊頁面
4. 串接後台API取得所有推文, 推文顯示前50個字(函式進行重構, 變得較為簡潔)
5. 串接後台API刪除一則推文
6. 串接後台API取得所有使用者資料, 依照推文數由高至低排序
7. 修正導覽列在單一回覆頁面 "首頁" 未顯示橘色的問題
8. 新增網站身分驗證: 
    -> 使用者未登入想從網址直接進入前或後台網頁-> 導向前台登入頁, 並提示請登入
    -> 使用者登入前台後，不會再進入前台登入及註冊頁(轉址首頁)
    -> 使用者登入前台,  想從網址直接進入後台網頁-> 導向not found
    -> 使用者登入後台,  想從網址直接進入前台網頁-> 導向前台登入頁
    -> 使用者登入後台後，不會再進入後台登入頁(轉址後台推文清單頁)
    
身分驗證邏輯我寫得有點複雜, 每行都有加入註解幫助理解code在寫什麼, 麻煩你了，謝謝~~